### PR TITLE
Update MoCo 'use negative examples' param name in blog code

### DIFF
--- a/train_blog.py
+++ b/train_blog.py
@@ -12,7 +12,7 @@ def main():
         batch_size=256,
         gather_keys_for_queue=False,
         loss_type="ip",
-        use_negative_examples=False,
+        use_negative_examples_from_queue=False,
         use_both_augmentations_as_queries=True,
         mlp_normalization="bn",
         prediction_mlp_layers=2,
@@ -26,7 +26,7 @@ def main():
         "proj_only": evolve(base_config, mlp_normalization="bn", prediction_mlp_normalization=None),
         "no_norm": evolve(base_config, mlp_normalization=None),
         "layer_norm": evolve(base_config, mlp_normalization="ln"),
-        "xent": evolve(base_config, use_negative_examples=True, loss_type="ce", mlp_normalization=None, lr=0.02),
+        "xent": evolve(base_config, use_negative_examples_from_queue=True, loss_type="ce", mlp_normalization=None, lr=0.02),
     }
     for seed in range(3):
         for name, config in configs.items():


### PR DESCRIPTION
I apologize if you're not looking for external contributions, this is just something small i noticed when trying to run the code for myself. It looks like one of the MoCoMethodParams attributes was updated in a [recent commit](https://github.com/untitled-ai/self_supervised/commit/8b5ed88818208997129b61c1f8577d12e47d0749#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R182) but the train_blog.py file was not updated accordingly.